### PR TITLE
fjerner attribut for institusjon pga endring i bruksarena-logikk i hm-soknad

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -9,6 +9,7 @@ on:
       - "docker-compose.yml"
     branches:
       - main
+      - fjern-institusjon
 
 jobs:
   call-workflow:

--- a/src/main/kotlin/no/nav/hm/grunndata/db/product/AttributeTagService.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/db/product/AttributeTagService.kt
@@ -27,15 +27,6 @@ class AttributeTagService(
             } else product.copy(attributes = product.attributes.copy(digitalSoknad = false))
         } ?: product
 
-    fun addIkkeTilInstitusjonAttribute(product: Product): Product =
-        product.isoCategory.let { isoCode ->
-            if (digihotSortiment.getIkkeTilInstitusjon(isoCode)) {
-                LOG.debug("Got product which is ikkeTilInstitusjon $isoCode")
-                product.copy(attributes = product.attributes.copy(ikkeTilInstitusjon=true))
-            }
-            else product.copy(attributes = product.attributes.copy(ikkeTilInstitusjon=false))
-        }
-
     fun addPakrevdGodkjenningskursAttribute(product: Product): Product =
         product.isoCategory.let { isoCode ->
             digihotSortiment.getPakrevdGodkjenningskurs(isoCode)?.let {

--- a/src/main/kotlin/no/nav/hm/grunndata/db/product/DigihotSortiment.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/db/product/DigihotSortiment.kt
@@ -17,8 +17,6 @@ class DigihotSortiment(
     private val bestillingsordningUrl : String,
     @Value("\${digihotSortiment.digitalSoknad}")
     private val digitalSoknadUrl : String,
-    @Value("\${digihotSortiment.ikkeTilInstitusjon}")
-    private val ikkeTilInstitusjonUrl : String,
     @Value("\${digihotSortiment.pakrevdGodkjenningskurs}")
     private val pakrevdGodkjenningskursUrl: String,
     @Value("\${digihotSortiment.produkttype}")
@@ -45,9 +43,6 @@ class DigihotSortiment(
             res
         }
 
-    private val ikkeTilInstitusjonMap: Map<String, IkkeTilInstitusjonDTO> =
-        objectMapper.readValue(URI(ikkeTilInstitusjonUrl).toURL(), object : TypeReference<List<IkkeTilInstitusjonDTO>>(){}).associateBy { it.isokode }
-
     private val pakrevdGodkjenningskursMap: Map<String, PakrevdGodkjenningskurs> =
         objectMapper.readValue(URI(pakrevdGodkjenningskursUrl).toURL(), object : TypeReference<List<PakrevdGodkjenningskurs>>(){}).associateBy { it.isokode }
 
@@ -60,11 +55,6 @@ class DigihotSortiment(
 
     fun getApostIdInDigitalCatalog(apostid: Int): Boolean {
         return digitalSoknadMap.containsKey(apostid)
-    }
-
-    fun getIkkeTilInstitusjon(isocode: String): Boolean {
-        val relevantIsoCodePrefix = isocode.take(6)
-        return ikkeTilInstitusjonMap.containsKey(relevantIsoCodePrefix)
     }
 
     fun getPakrevdGodkjenningskurs(isocode: String): PakrevdGodkjenningskurs? {
@@ -81,10 +71,6 @@ class DigihotSortiment(
 data class BestillingsordningDTO(
     val hmsnr: String,
     val navn: String,
-)
-
-data class IkkeTilInstitusjonDTO(
-    val isokode: String,
 )
 
 data class ProdukttypeDTO (

--- a/src/main/kotlin/no/nav/hm/grunndata/db/product/ProductService.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/db/product/ProductService.kt
@@ -40,7 +40,6 @@ open class ProductService(
         val product = prod
             .let { attributeTagService.addBestillingsordningAttribute(it) }
             .let { attributeTagService.addDigitalSoknadAttribute(it) }
-            .let { attributeTagService.addIkkeTilInstitusjonAttribute(it) }
             .let { attributeTagService.addPakrevdGodkjenningskursAttribute(it) }
             .let { attributeTagService.addProdukttypeAttribute(it) }
         val saved: Product = if (product.createdBy == HMDB) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,7 +101,6 @@ kafka:
 digihotSortiment:
   bestillingsordning: ${BESTILLINGSORDNING_URL:`https://navikt.github.io/digihot-sortiment/bestillingsordning_sortiment.json`}
   digitalSoknad: ${DIGITAL_SOKNAD_URL:`https://navikt.github.io/digihot-sortiment/sortiment_av_apostid_per_kategori.json`}
-  ikkeTilInstitusjon: ${IKKE_TIL_INSTITUSJON_URL:`https://navikt.github.io/digihot-sortiment/sortiment_ikke_til_institusjon.json`}
   pakrevdGodkjenningskurs: ${PAKREVD_GODKJENNINGSKURS_URL:`https://navikt.github.io/digihot-sortiment/paakrevde_godkjenningskurs.json`}
   produkttype: ${PRODUKTTYPE_URL:`https://navikt.github.io/digihot-sortiment/produkttype.json`}
 


### PR DESCRIPTION
hm-soknad har nå egen logikk for å bestemme hvilke valg for bruksarena som skal være tilgjengelig, og bruker ikke lenger det som ligger i digihot-sortiment.
Så vidt jeg vet er det ingen andre plasser denne infoen blir tatt i bruk. Er det noen andre apper som bruker hm-grunndata-db, som jeg også må sjekke? Har ikke klart å finne noe med kodesøk i Github.