### PR TITLE
Potential fix for code scanning alert no. 8: Deprecated method or constructor invocation

### DIFF
--- a/src/main/kotlin/no/nav/hm/grunndata/db/JacksonConfig.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/db/JacksonConfig.kt
@@ -17,7 +17,7 @@ class JacksonConfig : BeanCreatedEventListener<ObjectMapper> {
         objectMapper.registerModule(JavaTimeModule())
             .disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .configure(SerializationFeature.INDENT_OUTPUT, false)
         return objectMapper


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/hm-grunndata-db/security/code-scanning/8](https://github.com/navikt/hm-grunndata-db/security/code-scanning/8)

In general, the fix is to replace use of the deprecated `ObjectMapper.setSerializationInclusion(JsonInclude.Include)` with the recommended modern API. For Jackson 2.9+, the equivalent is to call `setDefaultPropertyInclusion(JsonInclude.Value.construct(include, include))` or similar, or to use `setSerializationInclusion(JsonInclude.Value)` depending on Jackson version. This preserves the intent (exclude nulls from serialization) while avoiding the deprecated method.

In this specific file, the line `.setSerializationInclusion(JsonInclude.Include.NON_NULL)` in the configuration chain should be replaced with the newer inclusion configuration. To keep behavior identical (omit null properties from serialization), we can call `setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.ALWAYS))`. However, a simpler and commonly used equivalent that matches the old method’s intent in most cases is `setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)`, which Jackson supports as an overload and which avoids the deprecated API. We will therefore replace the deprecated call with `.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)`. No new imports are needed because `JsonInclude` is already imported and we are still calling a method on `ObjectMapper`. The change occurs only in `src/main/kotlin/no/nav/hm/grunndata/db/JacksonConfig.kt`, within the `onCreated` method’s call chain.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
